### PR TITLE
Fix bug when converting with type hint

### DIFF
--- a/oneliner.py
+++ b/oneliner.py
@@ -75,6 +75,17 @@ class Converter:
 
         return out
 
+    @staticmethod
+    def arg_remove_annotation(arg: ast.arguments):
+        # Warning: In place operation
+        if not arg.vararg is None:
+            arg.vararg.annotation = None
+        if not arg.kwarg is None:
+            arg.kwarg.annotation = None
+        for args in [arg.posonlyargs, arg.args, arg.kwonlyargs]:
+            for _arg in args:
+                _arg.annotation = None
+
     def convert(self, body: list, recursion: int = 0):
         out_node = ast.List([])
 
@@ -378,6 +389,8 @@ class Converter:
             )
 
         def handle_def(def_statement: ast.FunctionDef):
+            self.arg_remove_annotation(def_statement.args)
+
             converter = Converter(isfunc=True)
             function_body = ast.Lambda(
                 args=def_statement.args,

--- a/oneliner_unitest.py
+++ b/oneliner_unitest.py
@@ -392,6 +392,14 @@ func()
 """
         self.check_convert(script)
 
+    def test_convert_function_with_type_hint(self):
+        script = """
+def func(a:int,/,b:int,*args:int,c:int=123,**kw:int) -> None:
+    print(a,b,args,c,kw)
+func(1,2,3,4,5,c=6,d=7,e=8)
+"""
+        self.check_convert(script)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Original**
```python
def func(a:int):
    print(a)
```
**Converted (Before Fix)**
```python
(func := (lambda a: int: [print(a), None][-1]))
```
which leads to a SyntaxError
**Converted (After Fix)**
```python
(func := (lambda a: [print(a), None][-1]))
```