### PR TITLE
Enhance code quality

### DIFF
--- a/oneliner.py
+++ b/oneliner.py
@@ -19,20 +19,6 @@ def unique_id() -> str:
     return uid
 
 
-def ast_walk(node: ast.AST, excludes: Optional[list] = None):
-    if excludes is None:
-        excludes = []
-    from collections import deque
-
-    todo = deque([node])
-    while todo:
-        node = todo.popleft()
-        if type(node) in excludes:
-            continue
-        todo.extend(ast.iter_child_nodes(node))
-        yield node
-
-
 def arg_remove_annotation(arg: ast.arguments) -> None:
     # Warning: In place operation
     if arg.vararg is not None:
@@ -164,7 +150,6 @@ class Converter:
         self.isfunc = isfunc
 
         self.loop_control_stack = []
-        self.names: set[str] = set()
 
         self.usesing_itertools = False
         self.filename = "<string>"
@@ -174,7 +159,6 @@ class Converter:
             self.not_return = ast.Name(id="__ol_not_return_" + _id)
             self.return_value = ast.Name(id="__ol_return_value_" + _id)
             self.have_return = False
-            self.global_names: set[str] = set()
 
         self.node_handler_map = {
             ast.Expr: self.handle_expr,
@@ -190,17 +174,10 @@ class Converter:
             ast.Continue: self.handle_continue,
             ast.Break: self.handle_break,
             ast.Return: self.handle_return,
-            ast.Global: self.handle_global,
         }
 
     def set_filename(self, name: str) -> None:
         self.filename = name
-
-    def update_names(self, nodes: list[ast.AST]) -> None:
-        for node in nodes:
-            for _node in ast_walk(node, excludes=[ast.Lambda]):
-                if isinstance(_node, ast.Name) and not _node.id.startswith("__ol_"):
-                    self.names.add(_node.id)
 
     def handle_for(self, for_statement: ast.For) -> list[ast.AST]:
         out = []
@@ -522,19 +499,6 @@ class Converter:
     def handle_expr(self, expr: ast.Expr) -> list[ast.AST]:
         return [expr]
 
-    def handle_global(self, global_statement: ast.Global) -> list[ast.AST]:
-        if not self.isfunc:
-            return []
-        for name in global_statement.names:
-            if name in self.names:
-                raise SyntaxError(
-                    f"Invalid Syntax.\n"
-                    f'File "{self.filename}", line {global_statement.lineno}\n'
-                    f"    Name '{name}' is used prior to global declaration."
-                )
-            self.global_names.add(name)
-        return []
-
     def convert(self, nodes: list[ast.AST], top_level: bool = False) -> ast.AST:
         out = []
 
@@ -548,7 +512,6 @@ class Converter:
 
             # Handle AST node
             converted_list = self.node_handler_map[type(node)](node)
-            self.update_names(converted_list)
             out.extend(converted_list)
 
             if type(node) in [ast.Continue, ast.Break, ast.Return]:


### PR DESCRIPTION
### 1. Use functions instead of staticmethod

### 2. Better error info
**Before**
```
__main__.ConvertError: Convert failed.
Error: ".\__devtmp__\test.py", line 3, Statement "Global" is not convertable.
```
**After**
```
__main__.ConvertError: Convert failed.
File "X:\python\一行代码转换器\__devtmp__\test.py", line 3
    Statement "Global" is not convertable.
```

### 3.Set `ctx` attribute for `ast.Name` and `ast.Attribute`
### 4.Add type hints

