### PR TITLE
Skip lambda when global assign

### DIFF
--- a/oneliner.py
+++ b/oneliner.py
@@ -262,6 +262,10 @@ def global_assign_pp(converter, node: ast.AST) -> ast.AST:
                 keywords=[],
             )
 
+        def visit_Lambda(self, node: ast.Lambda) -> ast.AST:
+            # skip lambda
+            return node
+
     _Transformer().visit(node)
     return node
 


### PR DESCRIPTION
**Original**
```python
a=1
def func():
    global a
    print((lambda a:(a:=0))(0))
func()
print(a)
```
**BeforeFix**
```py
...
(func := (lambda : [print((lambda a: __ol_global_assign('a', 0))(0)), None][-1]))
...
```
**AfterFix**
```py
...
(func := (lambda : [print((lambda a: (a := 0))(0)), None][-1]))
...
```
